### PR TITLE
Fix/Confluence upload using split_strategy

### DIFF
--- a/amazon_s3/s3reader.py
+++ b/amazon_s3/s3reader.py
@@ -396,7 +396,7 @@ class S3Reader(BaseReader):
             self.download_s3_file(self.key, temp_dir, file_paths)
             count = 1
         elif self.keys:
-            logging.getLogger().info(f"keys: '{self.keys.length}'")
+            logging.getLogger().info(f"keys: '{len(self.keys)}'")
             for key in self.keys:
                 self.download_s3_file(key, temp_dir, file_paths)
             count = len(self.keys)

--- a/atlassian_confluence/confluence_config.md
+++ b/atlassian_confluence/confluence_config.md
@@ -13,7 +13,9 @@ confluence:
   include_attachments: !!bool true|false (default)
   include_children: !!bool true|false (default)
   cloud: !!bool true|false (default)
-  namespace: !!str 'namespace name' # Must match the associated RAG assistant, check the index section
+  download_dir: !!str path to a folder where metadata is stored (mandatory for delta ingestion)
+  split_strategy: !!str None | id (create a id.json for each page)
+  namespace: !!str 'namespace name' # Must match the associated RAG assistant, check the index section (deprecated)
 saia:
   base_url: !!str 'string' # GeneXus Enterprise AI Base URL
   api_token: !!str 'string'

--- a/atlassian_jira/jirareader.py
+++ b/atlassian_jira/jirareader.py
@@ -2,7 +2,12 @@ from datetime import datetime
 import re
 from typing import Any, Dict, List
 
-from llama_index.readers.base import BaseReader
+try:
+    from llama_index.readers.base import BaseReader
+except LookupError as e:
+    import nltk
+    nltk.download('wordnet')
+    from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
 from llama_index.bridge.langchain import Document as LCDocument
 

--- a/atlassian_jira/jirareader.py
+++ b/atlassian_jira/jirareader.py
@@ -2,12 +2,7 @@ from datetime import datetime
 import re
 from typing import Any, Dict, List
 
-try:
-    from llama_index.readers.base import BaseReader
-except LookupError as e:
-    import nltk
-    nltk.download('wordnet')
-    from llama_index.readers.base import BaseReader
+from llama_index.readers.base import BaseReader
 from llama_index.readers.schema.base import Document
 from llama_index.bridge.langchain import Document as LCDocument
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2494,13 +2494,13 @@ test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
 
 [[package]]
 name = "nltk"
-version = "3.9"
+version = "3.8.1"
 description = "Natural Language Toolkit"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.7"
 files = [
-    {file = "nltk-3.9-py3-none-any.whl", hash = "sha256:d17863e861bb33ac617893329d71d06a3dfb7e3eb9ee0b8105281c53944a45a1"},
-    {file = "nltk-3.9.tar.gz", hash = "sha256:e98acac454407fa38b76cccb29208d377731cf7fab68f323754a3681f104531f"},
+    {file = "nltk-3.8.1-py3-none-any.whl", hash = "sha256:fd5c9109f976fa86bcadba8f91e47f5e9293bd034474752e92a520f81c93dda5"},
+    {file = "nltk-3.8.1.zip", hash = "sha256:1834da3d0682cba4f2cede2f9aad6b0fafb6461ba451db0efb6f9c39798d64d3"},
 ]
 
 [package.dependencies]
@@ -4618,4 +4618,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,<3.12"
-content-hash = "613d7d338a08f532d6a308d0e54374e5f9308d9f7a1025df8e8c5928ab8d8019"
+content-hash = "97b12ef8d0a1c44eaf6c1bbcbded2907dfe33f5557191cc896125977109ca320"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ pydrive = "^1.3.1"
 docx2txt = "^0.8"
 azure-identity = "^1.17.1"
 azure-keyvault-secrets = "^4.8.0"
+nltk = "3.8.1"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^3.1.0"

--- a/saia_ingest/profile_utils.py
+++ b/saia_ingest/profile_utils.py
@@ -79,7 +79,9 @@ def file_upload(
                 with open(file_path + '.saia.metadata', 'w') as file:
                     file.write(json.dumps(response_body, indent=2))
             end_time = time.time()
-            message_response = f"{response_body['indexStatus']}, {file_name},{response_body['name']},{response_body['id']},{end_time - start_time:.2f} seconds"
+            metadata_elements = response_body.get('metadata', [])
+            metadata_count_items = f",{len(metadata_elements)}" if len(metadata_elements) > 0 else ""
+            message_response = f"{response_body['indexStatus']}, {file_name},{response_body['name']},{response_body['id']}{metadata_count_items},{end_time - start_time:.2f} seconds"
         logging.getLogger().info(message_response)
     except Exception as e:
         if e.response['Error']['Code'] == '401':


### PR DESCRIPTION
For cases where the ingestion needs to be processed with a timestamp, added a `split_strategy` property to store items by ID and metadata to later delete elements if needed.