### PR TITLE
refactor: implement lazy imports to improve startup time

### DIFF
--- a/saia_ingest/__init__.py
+++ b/saia_ingest/__init__.py
@@ -1,7 +1,0 @@
-"""Init file"""
-
-from .ingestor import ingest_s3, ingest_jira, ingest_confluence, ingest_github
-
-def dummy():
-    print("Dummy function")
-    return

--- a/saia_ingest/command_line/command_line.py
+++ b/saia_ingest/command_line/command_line.py
@@ -5,28 +5,6 @@ from typing import Any, Optional
 from datetime import datetime, timezone, timedelta
 import logging
 import sys
-from logging.handlers import RotatingFileHandler
-
-from ..ingestor import ingest_s3, ingest_jira, ingest_confluence, ingest_github, ingest_gdrive, ingest_sharepoint, ingest_file_system
-from ..log import AccumulatingLogHandler
-
-import warnings
-warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
-warnings.filterwarnings("ignore", category=DeprecationWarning) 
-warnings.filterwarnings("ignore", category=SyntaxWarning, module='magic')
-
-logging.basicConfig(level=logging.INFO)
-sys.stdout.reconfigure(encoding='utf-8')
-timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-log_file_name = f"debug/run_{timestamp}.txt"
-log_dir = os.path.dirname(log_file_name)
-if not os.path.isdir(log_dir):
-    os.mkdir(log_dir)
-file_handler = RotatingFileHandler(log_file_name, maxBytes=1024*1024*1024, backupCount=50)
-formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
-file_handler.setFormatter(formatter)
-logging.getLogger().addHandler(file_handler)
-logging.getLogger().addHandler(AccumulatingLogHandler())
 
 def handle_ingest(
     config: Optional[str] = None,
@@ -38,6 +16,35 @@ def handle_ingest(
     """
     Handles the ingest command.
     """
+    from logging.handlers import RotatingFileHandler
+    from ..log import AccumulatingLogHandler
+    import warnings
+    
+    # Setup warnings
+    warnings.filterwarnings(action="ignore", message="unclosed", category=ResourceWarning)
+    warnings.filterwarnings("ignore", category=DeprecationWarning) 
+    warnings.filterwarnings("ignore", category=SyntaxWarning, module='magic')
+    
+    # Setup logging
+    logging.basicConfig(level=logging.INFO)
+    sys.stdout.reconfigure(encoding='utf-8')
+    log_timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_file_name = f"debug/run_{log_timestamp}.txt"
+    log_dir = os.path.dirname(log_file_name)
+    if not os.path.isdir(log_dir):
+        os.mkdir(log_dir)
+    
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    
+    file_handler = RotatingFileHandler(log_file_name, maxBytes=1024*1024*1024, backupCount=50)
+    file_handler.setFormatter(formatter)
+    logging.getLogger().addHandler(file_handler)
+    
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setFormatter(formatter)
+    logging.getLogger().addHandler(console_handler)
+    
+    logging.getLogger().addHandler(AccumulatingLogHandler())
 
     assert config is not None
     assert type is not None
@@ -51,18 +58,25 @@ def handle_ingest(
         timestamp = datetime.fromisoformat(timestamp).replace(tzinfo=timezone.utc)
 
     if type == "s3":
+        from ..ingestor import ingest_s3
         ret = ingest_s3(config_file, start_time, timestamp=timestamp)
     elif type == "sharepoint":
+        from ..ingestor import ingest_sharepoint
         ret = ingest_sharepoint(config_file, start_time)
     elif type == "jira":
+        from ..ingestor import ingest_jira
         ret = ingest_jira(config_file, timestamp=timestamp)
     elif type == "confluence":
+        from ..ingestor import ingest_confluence
         ret = ingest_confluence(config_file, timestamp=timestamp)
     elif type == "github":
+        from ..ingestor import ingest_github
         ret = ingest_github(config_file)
     elif type == "gdrive":
+        from ..ingestor import ingest_gdrive
         ret = ingest_gdrive(config_file, timestamp=timestamp)
     elif type == "fs":
+        from ..ingestor import ingest_file_system
         ret = ingest_file_system(config_file, timestamp=timestamp)
     else:
         logging.getLogger().error(f"Unknown {type} type")

--- a/saia_ingest/ingestor.py
+++ b/saia_ingest/ingestor.py
@@ -6,36 +6,21 @@ import json
 import concurrent.futures
 import traceback
 
-from langchain_text_splitters import RecursiveCharacterTextSplitter
-
-from saia_ingest.config import Defaults
-from saia_ingest.file_utils import calculate_file_hash, load_hashes_from_json
-from saia_ingest.profile_utils import get_name_from_metadata_file, is_valid_profile, file_upload, file_delete, operation_log_upload, sync_failed_files, search_failed_to_delete
-from saia_ingest.rag_api import RagApi
-from saia_ingest.utils import get_new_files, get_yaml_config, get_metadata_file, load_json_file
-
-# tweaked the implementation locally
-from atlassian_jira.jirareader import JiraReader
-from atlassian_confluence.confluencereader import ConfluenceReader
-from amazon_s3.s3reader import S3Reader
-from gdrive.gdrive_reader import GoogleDriveReader
-
-from llama_index.readers.github.repository.github_client import GithubClient
-from llama_index.readers.github import GithubRepositoryReader
-from fs.simple_folder_reader import SimpleDirectoryReader
-
-from saia_ingest.config import DefaultVectorStore
-
 from typing import List, Dict
 import logging
 import shutil
 
-from sharepoint.sharepoint_ingestor import Sharepoint_Ingestor
-
-
 verbose = False
 
-def split_documents(documents, chunk_size=DefaultVectorStore.CHUNK_SIZE, chunk_overlap=DefaultVectorStore.CHUNK_OVERLAP):
+def split_documents(documents, chunk_size=None, chunk_overlap=None):
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+    from saia_ingest.config import DefaultVectorStore
+    
+    if chunk_size is None:
+        chunk_size = DefaultVectorStore.CHUNK_SIZE
+    if chunk_overlap is None:
+        chunk_overlap = DefaultVectorStore.CHUNK_OVERLAP
+    
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
     lc_documents = text_splitter.split_documents(documents)
     return lc_documents
@@ -109,6 +94,11 @@ def ingest_jira(
         configuration: str,
         timestamp: datetime = None,
     ) -> bool:
+    from atlassian_jira.jirareader import JiraReader
+    from saia_ingest.rag_api import RagApi
+    from saia_ingest.utils import get_yaml_config
+    from saia_ingest.profile_utils import operation_log_upload
+    
     ret = True
     start_time = time.time()
     try:
@@ -474,6 +464,9 @@ def saia_file_upload(
         metadata_args: dict = None,
         optional_args: dict = None,
     ) -> bool:
+    from saia_ingest.utils import get_metadata_file
+    from saia_ingest.profile_utils import file_upload
+    
     ret = True
 
     file = os.path.normpath(file_item)
@@ -902,5 +895,7 @@ def ingest_sharepoint(
         configuration: str,
         start_time: datetime,
     ) -> bool:
+    from sharepoint.sharepoint_ingestor import Sharepoint_Ingestor
+    
     ingestor = Sharepoint_Ingestor(configuration, start_time)
     return ingestor.execute()


### PR DESCRIPTION
Move imports inside functions to defer loading until needed:
- saia_ingest/__init__.py: Remove module-level imports
- command_line.py: Move imports and logging setup into handle_ingest()
- ingestor.py: Move imports into split_documents(), ingest_jira(), and saia_file_upload()